### PR TITLE
RoadSystem can have missing number

### DIFF
--- a/src/main/java/no/vegvesen/nvdbapi/client/model/roadnet/roadsysref/RoadSystem.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/model/roadnet/roadsysref/RoadSystem.java
@@ -5,11 +5,11 @@ import java.util.Objects;
 public class RoadSystem {
     public final Long id;
     public final Integer version;
-    public final int roadNumber;
+    public final Integer roadNumber;
     public final String roadCategory;
     public final String phase;
 
-    public RoadSystem(Long id, Integer version, int roadNumber, String roadCategory, String phase) {
+    public RoadSystem(Long id, Integer version, Integer roadNumber, String roadCategory, String phase) {
         this.id = id;
         this.version = version;
         this.roadNumber = roadNumber;
@@ -37,7 +37,7 @@ public class RoadSystem {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RoadSystem that = (RoadSystem) o;
-        return roadNumber == that.roadNumber &&
+        return Objects.equals(roadNumber, that.roadNumber) &&
                 Objects.equals(id, that.id) &&
                 Objects.equals(version, that.version) &&
                 Objects.equals(roadCategory, that.roadCategory) &&

--- a/src/test/java/no/vegvesen/nvdbapi/client/gson/RoadSysRefParserTest.java
+++ b/src/test/java/no/vegvesen/nvdbapi/client/gson/RoadSysRefParserTest.java
@@ -1,0 +1,48 @@
+package no.vegvesen.nvdbapi.client.gson;
+
+import no.vegvesen.nvdbapi.client.model.roadnet.roadsysref.RoadSysRef;
+import no.vegvesen.nvdbapi.client.model.roadnet.roadsysref.RoadSystem;
+import org.junit.jupiter.api.Test;
+
+import static no.vegvesen.nvdbapi.client.gson.Helper.parseObject;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class RoadSysRefParserTest {
+
+    @Test
+    void parseRoadSystemWithNumber() {
+        RoadSysRef roadSysRef = parseObject("vegobjekter/vegsystemreferanse_med_nummer.json", RoadSysRefParser::parse);
+        assertThat(roadSysRef, notNullValue());
+        assertThat(roadSysRef.shortForm, equalTo("KV17 S1D1 m0-58"));
+    }
+
+    @Test
+    void parseRoadSystemWithoutNumber() {
+        RoadSysRef roadSysRef = parseObject("vegobjekter/vegsystemreferanse_uten_nummer.json", RoadSysRefParser::parse);
+        assertThat(roadSysRef, notNullValue());
+        assertThat(roadSysRef.shortForm, equalTo("KVnull S1D1 m0-58"));
+    }
+
+    @Test
+    void roadSystemWithoutNumberOperations() {
+        RoadSysRef roadSysRefOk = parseObject("vegobjekter/vegsystemreferanse_med_nummer.json", RoadSysRefParser::parse);
+        RoadSystem roadSystemOk = roadSysRefOk.getRoadSystem();
+        RoadSysRef roadSysRefMissingNumber = parseObject("vegobjekter/vegsystemreferanse_uten_nummer.json", RoadSysRefParser::parse);
+        RoadSystem roadSystemMissingNumber = roadSysRefMissingNumber.getRoadSystem();
+        RoadSysRef roadSysRefMissingNumberCopy = parseObject("vegobjekter/vegsystemreferanse_uten_nummer.json", RoadSysRefParser::parse);
+        RoadSystem roadSystemMissingNumberCopy = roadSysRefMissingNumberCopy.getRoadSystem();
+
+        assertThat(roadSystemMissingNumber, equalTo(roadSystemMissingNumberCopy));
+        assertThat(roadSystemMissingNumber, not(equalTo(roadSystemOk)));
+
+        assertThat(roadSystemMissingNumber.getCategoryPhaseNumberAsString(), equalTo("KVnull"));
+
+        assertThat(roadSystemMissingNumber.hashCode(), equalTo(roadSystemMissingNumberCopy.hashCode()));
+        assertThat(roadSystemMissingNumber.hashCode(), not(equalTo(roadSystemOk.hashCode())));
+
+        assertThat(roadSystemMissingNumber.toString(), equalTo("RoadSystem{id=1005921633, version=1, roadNumber=null, roadCategory='K', phase='V'}"));
+    }
+}

--- a/src/test/resources/jsonresponse/vegobjekter/vegsystemreferanse_med_nummer.json
+++ b/src/test/resources/jsonresponse/vegobjekter/vegsystemreferanse_med_nummer.json
@@ -1,0 +1,22 @@
+{
+  "vegsystem": {
+    "id": 1002135037,
+    "versjon": 1,
+    "vegkategori": "K",
+    "fase": "V",
+    "nummer": 17
+  },
+  "strekning": {
+    "id": -1,
+    "versjon": -1,
+    "strekning": 1,
+    "delstrekning": 1,
+    "arm": false,
+    "adskilte_løp": "Nei",
+    "trafikantgruppe": "K",
+    "fra_meter": 0.0,
+    "til_meter": 58.0,
+    "retning": "MED"
+  },
+  "kortform": "KV17 S1D1 m0-58"
+}

--- a/src/test/resources/jsonresponse/vegobjekter/vegsystemreferanse_uten_nummer.json
+++ b/src/test/resources/jsonresponse/vegobjekter/vegsystemreferanse_uten_nummer.json
@@ -1,0 +1,21 @@
+{
+  "vegsystem": {
+    "id": 1005921633,
+    "versjon": 1,
+    "vegkategori": "K",
+    "fase": "V"
+  },
+  "strekning": {
+    "id": -1,
+    "versjon": -1,
+    "strekning": 1,
+    "delstrekning": 1,
+    "arm": false,
+    "adskilte_løp": "Nei",
+    "trafikantgruppe": "K",
+    "fra_meter": 0.0,
+    "til_meter": 58.0,
+    "retning": "MED"
+  },
+  "kortform": "KVnull S1D1 m0-58"
+}


### PR DESCRIPTION
Getting NullPointerException when parsing Vegsystemreferanse with missing Nummer in RoadSysRefParser.parseRoadSystem. For some reason it is allowed from Les API. See https://www.vegvesen.no/nvdb/api/v3/vegobjekter/915/1005921633/1.