### PR TITLE
Timeout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog for NVDB API LES V3 Client
+
+## 1.7.0
+* `ClientConfiguration` has been added to allow setting read and connect timeouts for Jersey client.
+
 ## 1.6.0
 * `Statistics.length` changed from `long` to `double`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog for NVDB API LES V3 Client
 
-## 1.7.0
-* `ClientConfiguration` has been added to allow setting read and connect timeouts for Jersey client.
-
 ## 1.6.0
 * `Statistics.length` changed from `long` to `double`
+* `ClientConfiguration` has been added to allow setting read and connect timeouts for Jersey client.
 
 ## 1.5.0
 * RoadNetRequest.id, .superId changed from `List<Integer>` to `List<Long>`

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ RoadObject ro = client.getRoadObject(534, 1);
 // Remember to close your factory when you're done using it
 factory.close();
 ```
+ ### Setting timeouts for Jersey client.
+ To set a connect and read timeout for the nvdb-api-client. An instance of `ClientConfiguration` can be added when creating the `ClientFactory`
+ 
+ ```java
+// Add a read timeout of 5000 millis and connect timeout of 1000 millis
+ClientConfiguration clientConfig = new ClientConfiguration(5000, 1000);
+// Create a factory with timeout settings.
+ClientFactory factory = new ClientFactory("https://www.vegvesen.no/nvdb/api/v3", "nvdb-read-api-v3-client", clientConfig);
+```
+
 # How to build 
 The repo contains the Gradle wrapper. The client is built running:
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To start using the library simply instantiate the factory. It takes three argume
 ```java
 // First, create factory
 ClientFactory factory = new ClientFactory("https://www.vegvesen.no/nvdb/api/v3", "nvdb-read-api-v3-client");
-// Then, create your client. Typically, there's one per root endpoint
+// Then, create your client. Typically, there's one per root endpoint   
 RoadObjectClient client = factory.createRoadObjectClient();
 
 // Example single object download
@@ -72,7 +72,12 @@ factory.close();
  
  ```java
 // Add a read timeout of 5000 millis and connect timeout of 1000 millis
-ClientConfiguration clientConfig = new ClientConfiguration(5000, 1000);
+ClientConfiguration clientConfig = 
+    ClientConfigurationBuilder.builder()
+       .withReadTimeout(5000)
+       .withConnectTimeout(1000)
+       .build();
+
 // Create a factory with timeout settings.
 ClientFactory factory = new ClientFactory("https://www.vegvesen.no/nvdb/api/v3", "nvdb-read-api-v3-client", clientConfig);
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.2"
     testImplementation "org.hamcrest:hamcrest-all:1.3"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:2.26.0"
     testRuntimeOnly "org.slf4j:slf4j-simple:1.7.25"
 }
 

--- a/src/main/java/no/vegvesen/nvdbapi/client/ClientConfiguration.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/ClientConfiguration.java
@@ -1,0 +1,39 @@
+package no.vegvesen.nvdbapi.client;
+
+import java.util.Objects;
+
+public class ClientConfiguration {
+    private final int readTimeout;
+    private final int connectTimeout;
+
+    /**
+     * @param readTimeout in millis. Set the read timeout for the jersey client.
+     * @param connectTimeout in millis. Set the connect timeout for the jersey client.
+     */
+    public ClientConfiguration(int readTimeout, int connectTimeout) {
+        this.readTimeout = readTimeout;
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientConfiguration that = (ClientConfiguration) o;
+        return readTimeout == that.readTimeout &&
+                connectTimeout == that.connectTimeout;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(readTimeout, connectTimeout);
+    }
+}

--- a/src/main/java/no/vegvesen/nvdbapi/client/ClientConfiguration.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/ClientConfiguration.java
@@ -6,11 +6,7 @@ public class ClientConfiguration {
     private final int readTimeout;
     private final int connectTimeout;
 
-    /**
-     * @param readTimeout in millis. Set the read timeout for the jersey client.
-     * @param connectTimeout in millis. Set the connect timeout for the jersey client.
-     */
-    public ClientConfiguration(int readTimeout, int connectTimeout) {
+    private ClientConfiguration(int readTimeout, int connectTimeout) {
         this.readTimeout = readTimeout;
         this.connectTimeout = connectTimeout;
     }
@@ -21,6 +17,40 @@ public class ClientConfiguration {
 
     public int getConnectTimeout() {
         return connectTimeout;
+    }
+
+    public static final class ClientConfigurationBuilder {
+        private int readTimeout = 0;
+        private int connectTimeout = 0;
+
+        private ClientConfigurationBuilder() {
+        }
+
+        public static ClientConfigurationBuilder builder() {
+            return new ClientConfigurationBuilder();
+        }
+
+        /**
+         * @param readTimeout in millis. Set the read timeout for the jersey client.
+         * @return builder
+         */
+        public ClientConfigurationBuilder withReadTimeout(int readTimeout) {
+            this.readTimeout = readTimeout;
+            return this;
+        }
+
+        /**
+         * @param connectTimeout in millis. Set the connect timeout for the jersey client.
+         * @return builder
+         */
+        public ClientConfigurationBuilder withConnectTimeout(int connectTimeout) {
+            this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        public ClientConfiguration build() {
+            return new ClientConfiguration(readTimeout, connectTimeout);
+        }
     }
 
     @Override

--- a/src/test/java/no/vegvesen/nvdbapi/client/clients/ClientConfigurationTest.java
+++ b/src/test/java/no/vegvesen/nvdbapi/client/clients/ClientConfigurationTest.java
@@ -1,0 +1,50 @@
+package no.vegvesen.nvdbapi.client.clients;
+
+import javax.ws.rs.ProcessingException;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import no.vegvesen.nvdbapi.client.ClientConfiguration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ClientConfigurationTest {
+
+    private static WireMockServer wireMockServer;
+
+    @BeforeAll
+    public static void setUp() {
+        wireMockServer = new WireMockServer(options().port(8089));
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    public static void cleanUp() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    public void shouldHonorReadTimeout() {
+        configureFor("localhost", wireMockServer.port());
+        int delayInMillis = 200;
+        stubFor(get(urlEqualTo("/vegobjekttyper/versjon")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(delayInMillis)));
+
+        ClientFactory clientFactory = new ClientFactory(wireMockServer.baseUrl(),
+                "nvdbapi-client-test", new ClientConfiguration(delayInMillis - 100, delayInMillis * 10));
+        Exception exception = Assertions.assertThrows(ProcessingException.class, clientFactory::createAreaClient);
+        assertTrue(exception.getMessage().contains("Timeout"));
+    }
+}

--- a/src/test/java/no/vegvesen/nvdbapi/client/clients/ClientConfigurationTest.java
+++ b/src/test/java/no/vegvesen/nvdbapi/client/clients/ClientConfigurationTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import no.vegvesen.nvdbapi.client.ClientConfiguration;
+import no.vegvesen.nvdbapi.client.ClientConfiguration.ClientConfigurationBuilder;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
@@ -43,8 +43,12 @@ public class ClientConfigurationTest {
                         .withFixedDelay(delayInMillis)));
 
         ClientFactory clientFactory = new ClientFactory(wireMockServer.baseUrl(),
-                "nvdbapi-client-test", new ClientConfiguration(delayInMillis - 100, delayInMillis * 10));
+                "nvdbapi-client-test", ClientConfigurationBuilder.builder()
+                                                                 .withReadTimeout(delayInMillis - 100)
+                                                                 .withConnectTimeout(delayInMillis * 10)
+                                                                 .build());
         Exception exception = Assertions.assertThrows(ProcessingException.class, clientFactory::createAreaClient);
-        assertTrue(exception.getMessage().contains("Timeout"));
+        assertTrue(exception.getMessage()
+                            .contains("Timeout"));
     }
 }


### PR DESCRIPTION
Add a `ClientConfiguration` for setting read and connect timeout to the underlying jersey client. This class is named `ClientConfiguration` to avoid confusion with the Jersey class `ClientConfig`. This allows a user to optionally set a read and connect timeout for the client.

I have also added a test with wiremock. The test will introduce wiremock as a dependency to the project. The test is just testing the read timeout since it seemed impossible to set a connect timeout for the wiremock server. 