### PR TITLE
Remove datakat header from roadobjectclient

### DIFF
--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/ClientFactory.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/ClientFactory.java
@@ -277,12 +277,11 @@ public final class ClientFactory implements AutoCloseable {
 
     public RoadObjectClient createRoadObjectClient() {
         assertIsOpen();
-        Datakatalog datakatalog = getDatakatalog();
         RoadObjectClient c =
             new RoadObjectClient(
                 baseUrl,
-                createClient(datakatalog.getVersion().getVersion()),
-                datakatalog);
+                createClient()
+            );
         clients.add(c);
         return c;
     }
@@ -316,10 +315,6 @@ public final class ClientFactory implements AutoCloseable {
     }
 
     private Client createClient() {
-        return createClient(null);
-    }
-
-    private Client createClient(String datakatalogVersion) {
         ClientConfig config = new ClientConfig();
         config.register(GZipEncoder.class);
         config.register(DeflateEncoder.class);
@@ -335,7 +330,6 @@ public final class ClientFactory implements AutoCloseable {
                 userAgent,
                 xClientName,
                 xSession,
-                datakatalogVersion,
                 apiRevision,
                 authTokens));
 

--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadObjectClient.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadObjectClient.java
@@ -67,15 +67,9 @@ import static no.vegvesen.nvdbapi.client.gson.GsonUtil.rt;
 
 public class RoadObjectClient extends AbstractJerseyClient {
     private static final Logger logger = LoggerFactory.getLogger(RoadObjectClient.class);
-    private final Datakatalog datakatalog;
 
-    protected RoadObjectClient(String baseUrl, Client client, Datakatalog datakatalog) {
+    protected RoadObjectClient(String baseUrl, Client client) {
         super(baseUrl, client);
-        this.datakatalog = datakatalog;
-    }
-
-    public Datakatalog getDatakatalog() {
-        return datakatalog;
     }
 
     public Statistics getStats(int featureTypeId, RoadObjectRequest request) {

--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/filters/RequestHeaderFilter.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/filters/RequestHeaderFilter.java
@@ -36,25 +36,21 @@ import java.util.Arrays;
 public class RequestHeaderFilter implements ClientRequestFilter {
     private static final String X_CLIENT = "X-Client";
     private static final String X_SESSION = "X-Client-Session";
-    private static final String DAKAT_VERSION = "X-Datakatalog-Versjon";
 
     private final String userAgent;
     private final String xClientName;
     private final String xsessionId;
-    private final String dakatVersion;
     private final String apiRevision;
     private final Login.AuthTokens authTokens;
 
     public RequestHeaderFilter(String userAgent,
                                String xClientName,
                                String xsessionId,
-                               String dakatVersion,
                                String apiRevision,
                                Login.AuthTokens authTokens) {
         this.userAgent = userAgent;
         this.xClientName = xClientName;
         this.xsessionId = xsessionId;
-        this.dakatVersion = dakatVersion;
         this.apiRevision = apiRevision;
         this.authTokens = authTokens;
     }
@@ -68,7 +64,6 @@ public class RequestHeaderFilter implements ClientRequestFilter {
 
         headers.putSingle(X_CLIENT, xClientName);
         headers.putSingle(X_SESSION, xsessionId);
-        if (dakatVersion != null) headers.putSingle(DAKAT_VERSION, dakatVersion);
 
         if(authTokens != null) {
             headers.putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + authTokens.idToken);


### PR DESCRIPTION
This breaks the API since the public method `getDatakatalog` is removed
from RoadObjectClient. However, when this method is deleted there is no
furter use for datakatalog for RoadObjectClient and no other clients are
sending the datakat header. Therefore the sending for datakat header is
removed, but this breaks the semantics for the client since it will no
longer be able to detect datakatalog version changes.