### PR TITLE
Only fetch the datakatalog version.

### DIFF
--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/ClientFactory.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/ClientFactory.java
@@ -55,6 +55,7 @@ import no.vegvesen.nvdbapi.client.ProxyConfig;
 import no.vegvesen.nvdbapi.client.clients.filters.RequestHeaderFilter;
 import no.vegvesen.nvdbapi.client.gson.GsonMessageBodyHandler;
 import no.vegvesen.nvdbapi.client.model.datakatalog.Datakatalog;
+import no.vegvesen.nvdbapi.client.model.datakatalog.Version;
 import no.vegvesen.nvdbapi.client.util.LoggingFilter;
 
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -71,6 +72,7 @@ public final class ClientFactory implements AutoCloseable {
     private final ClientConfiguration clientConfig;
 
     private Datakatalog datakatalog;
+    private Version datakatalogVersion;
     private List<AbstractJerseyClient> clients;
     private boolean isClosed;
     private final Logger debugLogger;
@@ -268,6 +270,13 @@ public final class ClientFactory implements AutoCloseable {
         return datakatalog;
     }
 
+    public Version getDatakatalogVersion() {
+        if (datakatalogVersion == null) {
+            datakatalogVersion = createDatakatalogClient().getVersion();
+        }
+        return datakatalogVersion;
+    }
+
     public AreaClient createAreaClient() {
         assertIsOpen();
         AreaClient c = new AreaClient(baseUrl, createClient());
@@ -277,12 +286,11 @@ public final class ClientFactory implements AutoCloseable {
 
     public RoadObjectClient createRoadObjectClient() {
         assertIsOpen();
-        Datakatalog datakatalog = getDatakatalog();
         RoadObjectClient c =
             new RoadObjectClient(
                 baseUrl,
-                createClient(datakatalog.getVersion().getVersion()),
-                datakatalog);
+                createClient(getDatakatalogVersion().getVersion())
+            );
         clients.add(c);
         return c;
     }

--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadObjectClient.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadObjectClient.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 
 import no.vegvesen.nvdbapi.client.gson.RoadObjectParser;
 import no.vegvesen.nvdbapi.client.model.Page;
-import no.vegvesen.nvdbapi.client.model.datakatalog.Datakatalog;
 import no.vegvesen.nvdbapi.client.model.roadobjects.RoadObject;
 import no.vegvesen.nvdbapi.client.model.roadobjects.RoadObjectAttribute;
 import no.vegvesen.nvdbapi.client.model.roadobjects.RoadObjectType;
@@ -67,15 +66,9 @@ import static no.vegvesen.nvdbapi.client.gson.GsonUtil.rt;
 
 public class RoadObjectClient extends AbstractJerseyClient {
     private static final Logger logger = LoggerFactory.getLogger(RoadObjectClient.class);
-    private final Datakatalog datakatalog;
 
-    protected RoadObjectClient(String baseUrl, Client client, Datakatalog datakatalog) {
+    protected RoadObjectClient(String baseUrl, Client client) {
         super(baseUrl, client);
-        this.datakatalog = datakatalog;
-    }
-
-    public Datakatalog getDatakatalog() {
-        return datakatalog;
     }
 
     public Statistics getStats(int featureTypeId, RoadObjectRequest request) {


### PR DESCRIPTION
Note that this will break the client since the public method
`GetDatakatalog` is deleted from the road object client.

When creating a road object client we only need to fetch the datakatalog
version to set in the header, not the whole datakatalog.