### PR TITLE
Service Accounts (tjenestebrukere) need to be declared as such

### DIFF
--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/AuthClient.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/AuthClient.java
@@ -18,13 +18,17 @@ class AuthClient extends AbstractJerseyClient {
     }
 
     public Login login(String username, String password) {
+        return login(username, password, "employee");
+    }
+
+    public Login login(String username, String password, String userType) {
         UriBuilder path = start()
             .path("auth")
             .path("login");
         WebTarget target = getClient().target(path);
         try {
             Login.AuthTokens authTokens = target.request()
-                .post(Entity.entity(credentialsJson(username, password), APPLICATION_JSON_TYPE), Login.AuthTokens.class);
+                    .post(Entity.entity(credentialsJson(username, password, userType), APPLICATION_JSON_TYPE), Login.AuthTokens.class);
             return Login.success(authTokens);
         } catch (Exception e) {
             return Login.failed(e.getMessage());
@@ -51,10 +55,11 @@ class AuthClient extends AbstractJerseyClient {
     }
 
 
-    private Map<String, String> credentialsJson(String username, String password) {
+    private Map<String, String> credentialsJson(String username, String password, String userType) {
         Map<String, String> credentials = new HashMap<>();
         credentials.put("username", username);
         credentials.put("password", password);
+        credentials.put("user_type", userType);
         return credentials;
     }
 }

--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/ClientFactory.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/ClientFactory.java
@@ -182,6 +182,27 @@ public final class ClientFactory implements AutoCloseable {
     }
 
     /**
+     * Variant authentication for service accounts using username and password.
+     * If successful the {@code AuthTokens} recieved is used in followinf calls.
+     * @param username -
+     * @param password -
+     * @return {@code Login} containing either {@code AuthTokens} if successful or {@code Failure} if not
+     */
+    public Login serviceLogin(String username, String password) {
+        try {
+            AuthClient client = getAuthClient();
+            Login login = client.login(username, password,"serviceaccount");
+            if(login.isSuccessful()) {
+                this.authTokens = login.authTokens;
+            }
+            return login;
+        } catch (Exception e) {
+            debugLogger.error("Login failed", e);
+            return Login.failed(e.getMessage());
+        }
+    }
+
+    /**
      * clear the ClientFactory's auth tokens.
      */
     public void logout() {


### PR DESCRIPTION
Service Accounts (tjenestebrukere) need to be declared as such when logging in via auth/login, and so require a bit of special handling.