### PR TITLE
Add geometry tolerance option for road net requests

### DIFF
--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadNetClient.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadNetClient.java
@@ -138,6 +138,7 @@ public class RoadNetClient extends AbstractJerseyClient {
         request.getContractArea().ifPresent(v -> path.queryParam("kontraktsomrade", v));
         request.getNationalRoute().ifPresent(v -> path.queryParam("riksvegrute", v));
         request.getStreet().ifPresent(v -> path.queryParam("gate", v));
+        request.getDistanceTolerance().ifPresent(v -> path.queryParam("geometritoleranse", v));
     }
 
     private UriBuilder endpoint() {

--- a/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadNetRequest.java
+++ b/src/main/java/no/vegvesen/nvdbapi/client/clients/RoadNetRequest.java
@@ -58,6 +58,7 @@ public class RoadNetRequest {
     private final Set<TypeOfRoad> typeOfRoadFilter;
     private final Set<RefLinkPartType> refLinkPartTypeFilter;
     private final Set<DetailLevel> detailLevelFilter;
+    private final Integer distanceTolerance;
 
     private RoadNetRequest(Builder b) {
         page = b.page;
@@ -83,6 +84,7 @@ public class RoadNetRequest {
         refLinkPartTypeFilter = b.refLinkPartTypeFilter;
         detailLevelFilter = b.detailLevelFilter;
         typeOfRoadFilter = b.typeOfRoadFilter;
+        distanceTolerance = b.distanceTolerance;
 
     }
 
@@ -182,6 +184,10 @@ public class RoadNetRequest {
         return dateFilter;
     }
 
+    public Optional<Integer> getDistanceTolerance() {
+        return distanceTolerance;
+    }
+
     public static class Builder {
         private Optional<String> bpolygon = Optional.empty();
         private Optional<Page> page = Optional.empty();
@@ -206,6 +212,7 @@ public class RoadNetRequest {
         private Set<RefLinkPartType> refLinkPartTypeFilter = Collections.emptySet();
         private Set<DetailLevel> detailLevelFilter = Collections.emptySet();
         private Set<TypeOfRoad> typeOfRoadFilter = Collections.emptySet();
+        private Optional<Integer> distanceTolerance = Optional.empty();
 
         private Builder() {
         }


### PR DESCRIPTION
The rest API supports this according to [the swagger doc](https://nvdbapiles.atlas.vegvesen.no/dokumentasjon/openapi/swagger-ui/index.html#/Vegnett/get_vegnett_veglenkesekvenser_segmentert)
